### PR TITLE
store normalized dispersion in hvg_score

### DIFF
--- a/src/datasets/api/comp_processor_hvg.yaml
+++ b/src/datasets/api/comp_processor_hvg.yaml
@@ -16,8 +16,45 @@ functionality:
     - name: "--var_hvg_score"
       type: string
       default: "hvg_score"
-      description: "In which .var slot to store whether a ranking of the features by variance."
+      description: "In which .var slot to store the gene variance score (normalized dispersion)."
     - name: "--num_features"
       type: integer
       default: 1000
       description: "The number of HVG to select"
+  test_resources:
+    - type: python_script
+      path: generic_test.py
+      text: |
+        import scanpy as sc
+        import subprocess
+        from os import path
+
+        input_path = meta["resources_dir"] + "/pancreas/dataset.h5ad"
+        output_path = "output.h5ad"
+
+        cmd = [
+          meta['executable'],
+          "--input", input_path,
+          "--output", output_path,
+        ]
+
+        print(">> Running script as test")
+        out = subprocess.check_output(cmd).decode("utf-8")
+
+        print(">> Checking whether output file exists")
+        assert path.exists(output_path)
+
+        print(">> Reading h5ad files")
+        input = ad.read_h5ad(input_path)
+        output = ad.read_h5ad(output_path)
+        print("input:", input)
+        print("output:", output)
+
+        print(">> Checking whether output data structures were added")
+        assert par["var_hvg"] in output.var
+
+        print("Checking whether data from input was copied properly to output")
+        assert input.n_obs == output.n_obs
+        assert input.uns["dataset_id"] == output.uns["dataset_id"]
+
+        print("All checks succeeded!")

--- a/src/datasets/api/comp_processor_hvg.yaml
+++ b/src/datasets/api/comp_processor_hvg.yaml
@@ -22,12 +22,14 @@ functionality:
       default: 1000
       description: "The number of HVG to select"
   test_resources:
+    - path: ../../../../resources_test/common/pancreas
     - type: python_script
       path: generic_test.py
       text: |
-        import scanpy as sc
+        import anndata as ad
         import subprocess
         from os import path
+        import yaml
 
         input_path = meta["resources_dir"] + "/pancreas/dataset.h5ad"
         output_path = "output.h5ad"
@@ -38,8 +40,22 @@ functionality:
           "--output", output_path,
         ]
 
+        with open(meta["config"], "r") as file:
+            config = yaml.safe_load(file)
+        
+        for arg in config["functionality"]["arguments"]:
+          if arg['name'] == '--layer_input':
+            layer_input = arg['default'][0]
+            cmd += ['--layer_input', layer_input]
+          elif arg['name'] == '--var_hvg':
+            var_hvg = arg['default'][0]
+            cmd += ['--var_hvg', var_hvg]
+          elif arg['name'] == '--var_hvg_score':
+            var_hvg_score = arg['default'][0]
+            cmd += ['--var_hvg_score', var_hvg_score]
+
         print(">> Running script as test")
-        out = subprocess.check_output(cmd).decode("utf-8")
+        out = subprocess.check_output(cmd)
 
         print(">> Checking whether output file exists")
         assert path.exists(output_path)
@@ -51,7 +67,9 @@ functionality:
         print("output:", output)
 
         print(">> Checking whether output data structures were added")
-        assert par["var_hvg"] in output.var
+        assert layer_input in output.layers
+        assert var_hvg in output.var
+        assert var_hvg_score in output.var
 
         print("Checking whether data from input was copied properly to output")
         assert input.n_obs == output.n_obs

--- a/src/datasets/processors/hvg/config.vsh.yaml
+++ b/src/datasets/processors/hvg/config.vsh.yaml
@@ -17,5 +17,6 @@ platforms:
       - type: python
         packages:
           - scanpy
-          -  "anndata>=0.8"
+          - "anndata>=0.8"
+          - pyyaml
   - type: nextflow

--- a/src/datasets/processors/hvg/script.py
+++ b/src/datasets/processors/hvg/script.py
@@ -29,7 +29,7 @@ out = sc.pp.highly_variable_genes(
 
 print(">> Storing output")
 adata.var[par["var_hvg"]] = out['highly_variable'].values
-adata.var[par["var_hvg_score"]] = out['dispersions'].values
+adata.var[par["var_hvg_score"]] = out['dispersions_norm'].values
 
 print(">> Writing data")
 adata.write_h5ad(par['output'])


### PR DESCRIPTION
- Fix: `hvg_score` column in `.var` matrix should store the normalized dispersion values and not the means. 
- Add: unit test has been added to the `hvg` component of `datasets` task.