### PR TITLE
remove remaining `bin/` from bash scripts and contributing md

### DIFF
--- a/CONTRIBUTING.qmd
+++ b/CONTRIBUTING.qmd
@@ -151,7 +151,6 @@ You can start creating a new component by [creating a Viash component](https://v
 
 
 ```{bash, include=FALSE}
-# bin/viash_skeleton --name foo --namespace "label_projection/methods" --language python
 
 mkdir -p src/label_projection/methods/foo
 
@@ -239,13 +238,13 @@ src/label_projection/methods/foo/script.py
 You can view the interface of the executable by running the executable with the `-h` or `--help` parameter.
 
 ```{bash}
-bin/viash run src/label_projection/methods/foo/config.vsh.yaml -- --help
+viash run src/label_projection/methods/foo/config.vsh.yaml -- --help
 ```
 
 You can **run the component** as follows:
 
 ```{bash}
-bin/viash run src/label_projection/methods/foo/config.vsh.yaml -- \
+viash run src/label_projection/methods/foo/config.vsh.yaml -- \
   --input_train resources_test/label_projection/pancreas/train.h5ad \
   --input_test resources_test/label_projection/pancreas/test.h5ad \
   --output resources_test/label_projection/pancreas/prediction.h5ad
@@ -260,12 +259,12 @@ This standalone executable you can give to somebody else, and they will be able 
 run it, provided that they have Bash and Docker installed.
 
 ```{bash}
-bin/viash build src/label_projection/methods/foo/config.vsh.yaml \
+viash build src/label_projection/methods/foo/config.vsh.yaml \
   -o target/docker/label_projection/methods/foo
 ```
 
 :::{.callout-note}
-The `bin/viash_build` component does a much better job of setting up 
+The `viash ns build` component does a much better job of setting up 
 a collection of components.
 :::
 
@@ -291,7 +290,7 @@ The [method API specifications](src/label_projection/api/comp_method.yaml) comes
 This means you can unit test your component using the **`viash test`** command.
 
 ```{bash}
-bin/viash test src/label_projection/methods/foo/config.vsh.yaml
+viash test src/label_projection/methods/foo/config.vsh.yaml
 ```
 
 ```{bash include=FALSE}
@@ -335,7 +334,7 @@ src/label_projection/methods/foo/script.py
 If we now run the test, we should get an error since we didn't create all of the required output slots.
 
 ```{bash error=TRUE}
-bin/viash test src/label_projection/methods/foo/config.vsh.yaml
+viash test src/label_projection/methods/foo/config.vsh.yaml
 ```
 
 

--- a/src/datasets/loaders/openproblems_v1/run.sh
+++ b/src/datasets/loaders/openproblems_v1/run.sh
@@ -8,7 +8,7 @@ cd "$REPO_ROOT"
 
 export NXF_VER=22.04.5
 
-bin/nextflow \
+nextflow \
   run . \
   -main-script target/nextflow/datasets/loaders/openproblems_v1/main.nf \
   -resume \

--- a/src/datasets/resource_scripts/openproblems_v1.sh
+++ b/src/datasets/resource_scripts/openproblems_v1.sh
@@ -73,7 +73,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/datasets/workflows/process_openproblems_v1/main.nf \
   -profile docker \

--- a/src/denoising/resources_scripts/run_benchmark.sh
+++ b/src/denoising/resources_scripts/run_benchmark.sh
@@ -62,7 +62,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/denoising/workflows/run/main.nf \
   -profile docker \
@@ -73,10 +73,10 @@ bin/nextflow \
 bin/tools/docker/nextflow/process_log/process_log \
   --output "$OUTPUT_DIR/nextflow_log.tsv"
 
-# bin/viash_build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "id: $id, args: $args"'
-# bin/viash_build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "$id"'
+# viash ns build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "id: $id, args: $args"'
+# viash ns build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "$id"'
 
-# bin/nextflow run . \
+# nextflow run . \
 #   -main-script target/nextflow/label_projection/control_methods/majority_vote/main.nf \
 #   -profile docker \
 #   --input_train resources_test/label_projection/pancreas/train.h5ad \

--- a/src/denoising/resources_scripts/split_datasets.sh
+++ b/src/denoising/resources_scripts/split_datasets.sh
@@ -52,7 +52,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script target/nextflow/denoising/split_dataset/main.nf \
   -profile docker \

--- a/src/denoising/resources_test_scripts/pancreas.sh
+++ b/src/denoising/resources_test_scripts/pancreas.sh
@@ -40,7 +40,7 @@ bin/viash run src/denoising/metrics/poisson/config.vsh.yaml -- \
 # run benchmark
 export NXF_VER=22.04.5
 
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/denoising/workflows/run/main.nf \
   -profile docker \

--- a/src/dimensionality_reduction/resources_scripts/run_benchmark.sh
+++ b/src/dimensionality_reduction/resources_scripts/run_benchmark.sh
@@ -59,7 +59,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/dimensionality_reduction/workflows/run/main.nf \
   -profile docker \

--- a/src/dimensionality_reduction/resources_scripts/split_datasets.sh
+++ b/src/dimensionality_reduction/resources_scripts/split_datasets.sh
@@ -57,7 +57,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script target/nextflow/dimensionality_reduction/split_dataset/main.nf \
   -profile docker \

--- a/src/dimensionality_reduction/resources_test_scripts/pancreas.sh
+++ b/src/dimensionality_reduction/resources_test_scripts/pancreas.sh
@@ -40,7 +40,7 @@ viash run src/dimensionality_reduction/metrics/rmse/config.vsh.yaml -- \
 export NXF_VER=22.04.5
 
 # after having added a split dataset component
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/dimensionality_reduction/workflows/run/main.nf \
   -profile docker \

--- a/src/label_projection/resources_scripts/run_benchmark.sh
+++ b/src/label_projection/resources_scripts/run_benchmark.sh
@@ -61,7 +61,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/label_projection/workflows/run/main.nf \
   -profile docker \
@@ -72,10 +72,10 @@ bin/nextflow \
 bin/tools/docker/nextflow/process_log/process_log \
   --output "$OUTPUT_DIR/nextflow_log.tsv"
 
-# bin/viash_build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "id: $id, args: $args"'
-# bin/viash_build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "$id"'
+# viash ns build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "id: $id, args: $args"'
+# viash ns build -q label_projection -c '.platforms[.type == "nextflow"].directives.tag := "$id"'
 
-# bin/nextflow run . \
+# nextflow run . \
 #   -main-script target/nextflow/label_projection/control_methods/majority_vote/main.nf \
 #   -profile docker \
 #   --input_train resources_test/label_projection/pancreas/train.h5ad \

--- a/src/label_projection/resources_scripts/split_datasets.sh
+++ b/src/label_projection/resources_scripts/split_datasets.sh
@@ -56,7 +56,7 @@ HERE
 fi
 
 export NXF_VER=22.04.5
-bin/nextflow \
+nextflow \
   run . \
   -main-script target/nextflow/label_projection/split_dataset/main.nf \
   -profile docker \

--- a/src/label_projection/resources_test_scripts/pancreas.sh
+++ b/src/label_projection/resources_test_scripts/pancreas.sh
@@ -42,7 +42,7 @@ bin/viash run src/label_projection/metrics/accuracy/config.vsh.yaml -- \
 # run benchmark
 export NXF_VER=22.04.5
 
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/label_projection/workflows/run/main.nf \
   -profile docker \

--- a/src/label_projection/workflows/run/run_test.sh
+++ b/src/label_projection/workflows/run/run_test.sh
@@ -20,7 +20,7 @@ fi
 # run benchmark
 export NXF_VER=22.04.5
 
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/label_projection/workflows/run/main.nf \
   -profile docker \

--- a/src/modality_alignment/workflows/run/run_nextflow.sh
+++ b/src/modality_alignment/workflows/run/run_nextflow.sh
@@ -12,7 +12,7 @@ cd "$REPO_ROOT"
 # choose a particular version of nextflow
 export NXF_VER=21.10.6
 
-bin/nextflow \
+nextflow \
   run . \
   -main-script src/modality_alignment/workflows/run/main.nf \
   --publish_dir output/modality_alignment \


### PR DESCRIPTION
remove `bin/` from relevant Nextflow and viash commands.

`bin/` was still present in files where it was needed according to #41.
This PR fixes #41.
remaining `bin/` will be removed on other PR's