### PR TITLE
include types in api

### DIFF
--- a/src/denoising/api/comp_control_method.yaml
+++ b/src/denoising/api/comp_control_method.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: control_method
   arguments:
     - name: "--input_train"
       __merge__: anndata_train.yaml

--- a/src/denoising/api/comp_method.yaml
+++ b/src/denoising/api/comp_method.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: method
   arguments:
     - name: "--input_train"
       __merge__: anndata_train.yaml

--- a/src/denoising/api/comp_metric.yaml
+++ b/src/denoising/api/comp_metric.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: metric
   arguments:
     - name: "--input_test"
       __merge__: anndata_test.yaml

--- a/src/denoising/api/comp_split_dataset.yaml
+++ b/src/denoising/api/comp_split_dataset.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: split_dataset
   arguments:
     - name: "--input"
       __merge__: anndata_dataset.yaml

--- a/src/denoising/control_methods/no_denoising/config.vsh.yaml
+++ b/src/denoising/control_methods/no_denoising/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "denoising/control_methods"
   description: "negative control by copying train counts"
   info:
-    type: negative_control
+    subtype: negative_control
     method_name: No Denoising
     v1_url: openproblems/tasks/denoising/methods/baseline.py
     v1_commit: 29803b95c88b4ec5921df2eec7111fd5d1a95daf

--- a/src/denoising/control_methods/perfect_denoising/config.vsh.yaml
+++ b/src/denoising/control_methods/perfect_denoising/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "denoising/control_methods"
   description: "Negative control by copying the train counts"
   info:
-    type: positive_control
+    subtype: positive_control
     method_name: Perfect Denoising
     v1_url: openproblems/tasks/denoising/methods/baseline.py
     v1_commit: 29803b95c88b4ec5921df2eec7111fd5d1a95daf

--- a/src/denoising/methods/alra/config.vsh.yaml
+++ b/src/denoising/methods/alra/config.vsh.yaml
@@ -12,7 +12,6 @@ functionality:
     Next, each row (gene) is thresholded by the magnitude of the most negative value of that gene. 
     Finally, the matrix is rescaled.
   info:
-    type: method
     method_name: ALRA
     paper_reference: "linderman2018zero"
     code_url: "https://github.com/KlugerLab/ALRA"

--- a/src/denoising/methods/dca/config.vsh.yaml
+++ b/src/denoising/methods/dca/config.vsh.yaml
@@ -8,7 +8,6 @@ functionality:
     Removes the dropout effect by taking the count structure, overdispersed nature and sparsity of the data into account 
     using a deep autoencoder with zero-inflated negative binomial (ZINB) loss function.
   info:
-    type: method
     method_name: DCA
     paper_reference: "https://www.nature.com/articles/s41467-018-07931-2"
     code_url: "https://github.com/theislab/dca"

--- a/src/denoising/methods/knn_smoothing/config.vsh.yaml
+++ b/src/denoising/methods/knn_smoothing/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "denoising/methods"
   description: "iterative K-nearest neighbor smoothing"
   info:
-    type: method
     method_name: KNN Smoothing
     paper_reference: "wagner2018knearest"
     code_url: "https://github.com/yanailab/knn-smoothing"

--- a/src/denoising/methods/magic/config.vsh.yaml
+++ b/src/denoising/methods/magic/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "denoising/methods"
   description: "MAGIC: Markov affinity-based graph imputation of cells"
   info:
-    type: method
     method_name: MAGIC
     paper_reference: "https://doi.org/10.1016/j.cell.2018.05.061"
     code_url: "https://github.com/KrishnaswamyLab/MAGIC"

--- a/src/dimensionality_reduction/api/comp_control_method.yaml
+++ b/src/dimensionality_reduction/api/comp_control_method.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: control_method
   arguments:
     - name: "--input"
       __merge__: anndata_dataset.yaml

--- a/src/dimensionality_reduction/api/comp_method.yaml
+++ b/src/dimensionality_reduction/api/comp_method.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: method
   arguments:
     - name: "--input"
       __merge__: anndata_train.yaml

--- a/src/dimensionality_reduction/api/comp_metric.yaml
+++ b/src/dimensionality_reduction/api/comp_metric.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: metric
   arguments:
     - name: "--input_reduced"
       __merge__: anndata_reduced.yaml

--- a/src/dimensionality_reduction/api/comp_split_dataset.yaml
+++ b/src/dimensionality_reduction/api/comp_split_dataset.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: split_dataset
   arguments:
     - name: "--input"
       __merge__: anndata_dataset.yaml

--- a/src/dimensionality_reduction/control_methods/random_features/config.vsh.yaml
+++ b/src/dimensionality_reduction/control_methods/random_features/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "dimensionality_reduction/control_methods"
   description: "Uses a normal distribution to generate random embeddings."
   info:
-    type: negative_control
+    subtype: negative_control
     method_name: Random Features
     v1_url: openproblems/tasks/dimensionality_reduction/methods/baseline.py
     v1_commit: 14d70b330cae09527a6d4c4e552db240601e31cf

--- a/src/dimensionality_reduction/control_methods/true_features/config.vsh.yaml
+++ b/src/dimensionality_reduction/control_methods/true_features/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "dimensionality_reduction/control_methods"
   description: "Positive control method which generates high-dimensional (full data) embedding"
   info:
-    type: positive_control
+    subtype: positive_control
     label: True Features
     v1_url: openproblems/tasks/dimensionality_reduction/methods/baseline.py
     v1_comp_id: "True Features"

--- a/src/dimensionality_reduction/methods/densmap/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/densmap/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "dimensionality_reduction/methods"
   description: "Density-preserving UMAP"
   info:
-    type: method
     method_name: densMAP
     paper_reference: "narayan2021assessing"
     code_url: https://github.com/lmcinnes/umap

--- a/src/dimensionality_reduction/methods/ivis/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/ivis/config.vsh.yaml
@@ -9,7 +9,6 @@ functionality:
     ivis preserves global data structures in a low-dimensional space, adds new data points to existing embeddings using
     a parametric mapping function, and scales linearly to millions of observations.
   info:
-    type: method
     method_name: "ivis"
     paper_reference: szubert2019structurepreserving
     code_url: https://github.com/beringresearch/ivis

--- a/src/dimensionality_reduction/methods/neuralee/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/neuralee/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "dimensionality_reduction/methods"
   description: "A neural network implementation of elastic embedding implemented in the [NeuralEE package](https://neuralee.readthedocs.io/en/latest/)."
   info:
-    type: method
     method_name: NeuralEE
     paper_reference: "xiong2020neuralee"
     code_url: https://github.com/HiBearME/NeuralEE

--- a/src/dimensionality_reduction/methods/pca/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/pca/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "dimensionality_reduction/methods"
   description: "Principal component analysis (PCA)"
   info:
-    type: method
     method_name: "PCA"
     paper_reference: pearson1901pca
     code_url: https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html

--- a/src/dimensionality_reduction/methods/phate/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/phate/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "dimensionality_reduction/methods"
   description: "Potential of heat-diffusion for affinity-based transition embedding"
   info:
-    type: method
     method_name: PHATE
     paper_reference: "moon2019visualizing"
     code_url: https://github.com/KrishnaswamyLab/PHATE/

--- a/src/dimensionality_reduction/methods/tsne/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/tsne/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "dimensionality_reduction/methods"
   description: "t-Distributed Stochastic Neighbor Embedding (t-SNE)"
   info:
-    type: method
     method_name: t-SNE
     paper_reference: vandermaaten2008visualizing
     code_url: https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html#sklearn.manifold.TSNE

--- a/src/dimensionality_reduction/methods/umap/config.vsh.yaml
+++ b/src/dimensionality_reduction/methods/umap/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "dimensionality_reduction/methods"
   description: "Uniform Manifold Approximation and Projection for Dimension Reduction"
   info:
-    type: method
     label: UMAP
     paper_doi: "10.1038/s41587-020-00801-7"
     code_url: https://github.com/lmcinnes/umap

--- a/src/label_projection/api/comp_control_method.yaml
+++ b/src/label_projection/api/comp_control_method.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: control_method
   arguments:
     - name: "--input_train"
       __merge__: anndata_train.yaml

--- a/src/label_projection/api/comp_method.yaml
+++ b/src/label_projection/api/comp_method.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: method
   arguments:
     - name: "--input_train"
       __merge__: anndata_train.yaml

--- a/src/label_projection/api/comp_metric.yaml
+++ b/src/label_projection/api/comp_metric.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: metric
   arguments:
     - name: "--input_solution"
       __merge__: anndata_solution.yaml

--- a/src/label_projection/api/comp_split_dataset.yaml
+++ b/src/label_projection/api/comp_split_dataset.yaml
@@ -1,4 +1,6 @@
 functionality:
+  info:
+    type: split_dataset
   arguments:
     - name: "--input"
       __merge__: ../../datasets/api/anndata_dataset.yaml

--- a/src/label_projection/control_methods/majority_vote/config.vsh.yaml
+++ b/src/label_projection/control_methods/majority_vote/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "label_projection/control_methods"
   description: "Baseline method using majority voting"
   info:
-    type: negative_control
+    subtype: negative_control
     label: Majority Vote
     v1_url: openproblems/tasks/label_projection/methods/baseline.py
     v1_commit: b460ecb183328c857cbbf653488f522a4034a61c

--- a/src/label_projection/control_methods/random_labels/config.vsh.yaml
+++ b/src/label_projection/control_methods/random_labels/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "label_projection/control_methods"
   description: "Negative control method which generates random labels"
   info:
-    type: negative_control
+    subtype: negative_control
     label: Random Labels
     v1_url: openproblems/tasks/label_projection/methods/baseline.py
     v1_commit: b460ecb183328c857cbbf653488f522a4034a61c

--- a/src/label_projection/control_methods/true_labels/config.vsh.yaml
+++ b/src/label_projection/control_methods/true_labels/config.vsh.yaml
@@ -4,7 +4,7 @@ functionality:
   namespace: "label_projection/control_methods"
   description: "Positive control method by returning the true labels"
   info:
-    type: positive_control
+    subtype: positive_control
     label: True labels
     v1_url: openproblems/tasks/label_projection/methods/baseline.py
     v1_commit: b460ecb183328c857cbbf653488f522a4034a61c

--- a/src/label_projection/methods/knn/config.vsh.yaml
+++ b/src/label_projection/methods/knn/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "label_projection/methods"
   description: "K-Nearest Neighbors classifier"
   info:
-    type: method
     label: KNN
     # paper_name: "Nearest neighbor pattern classification"
     # paper_url: "https://doi.org/10.1109/TIT.1967.1053964"

--- a/src/label_projection/methods/logistic_regression/config.vsh.yaml
+++ b/src/label_projection/methods/logistic_regression/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "label_projection/methods"
   description: "Logistic regression method"
   info:
-    type: method
     label: Logistic Regression
     paper_name: "Applied Logistic Regression"
     paper_url: "https://books.google.com/books?id=64JYAwAAQBAJ"

--- a/src/label_projection/methods/mlp/config.vsh.yaml
+++ b/src/label_projection/methods/mlp/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "label_projection/methods"
   description: "Multilayer perceptron"
   info:
-    type: method
     label: Multilayer perceptron
     # paper_name: "Connectionist learning procedures"
     # paper_url: "https://doi.org/10.1016/0004-3702(89)90049-0"

--- a/src/label_projection/methods/scanvi/config.vsh.yaml
+++ b/src/label_projection/methods/scanvi/config.vsh.yaml
@@ -6,7 +6,6 @@ functionality:
     Probabilistic harmonization and annotation of single-cell 
     transcriptomics data with deep generative models.
   info:
-    type: method
     label: SCANVI
     paper_doi: "10.1101/2020.07.16.205997"
     code_url: "https://github.com/YosefLab/scvi-tools"

--- a/src/label_projection/methods/seurat_transferdata/config.vsh.yaml
+++ b/src/label_projection/methods/seurat_transferdata/config.vsh.yaml
@@ -6,7 +6,6 @@ functionality:
     The Seurat v3 anchoring procedure is designed to integrate
     diverse single-cell datasets across technologies and modalities. 
   info:
-    type: method
     label: Seurat TransferData
     paper_doi: "10.1101/460147"
     code_url: "https://github.com/satijalab/seurat"

--- a/src/label_projection/methods/xgboost/config.vsh.yaml
+++ b/src/label_projection/methods/xgboost/config.vsh.yaml
@@ -4,7 +4,6 @@ functionality:
   namespace: "label_projection/methods"
   description: "XGBoost: A Scalable Tree Boosting System"
   info:
-    type: method
     label: XGBoost
     paper_doi: 10.1145/2939672.2939785
     code_url: "https://github.com/dmlc/xgboost"


### PR DESCRIPTION
Added the `.info.type` directly in the component api.

The `subtype` field is used for being able to specify whether a control method is a positive or a negative control, as well as for different types of methods (e.g. in the batch integration task).