### PR TITLE
Remove --hvg from methods

### DIFF
--- a/src/tasks/batch_integration/api/comp_control_method_embedding.yaml
+++ b/src/tasks/batch_integration/api/comp_control_method_embedding.yaml
@@ -17,11 +17,6 @@ functionality:
       direction: output
       __merge__: file_integrated_embedding.yaml
       required: true
-    - name: --hvg
-      type: boolean
-      description: Whether to subset to highly variable genes
-      default: false
-      required: false
   test_resources:
     - type: python_script
       path: /src/common/comp_tests/check_method_config.py

--- a/src/tasks/batch_integration/api/comp_control_method_graph.yaml
+++ b/src/tasks/batch_integration/api/comp_control_method_graph.yaml
@@ -17,11 +17,6 @@ functionality:
       name: --output
       direction: output
       required: true
-    - name: --hvg
-      type: boolean
-      description: Whether to subset to highly variable genes
-      default: false
-      required: false
   test_resources:
     - type: python_script
       path: /src/common/comp_tests/check_method_config.py

--- a/src/tasks/batch_integration/api/comp_method_embedding.yaml
+++ b/src/tasks/batch_integration/api/comp_method_embedding.yaml
@@ -17,11 +17,6 @@ functionality:
       __merge__: file_integrated_embedding.yaml
       direction: output
       required: true
-    - name: --hvg
-      type: boolean
-      description: Whether to subset to highly variable genes
-      default: false
-      required: false
   test_resources:
     # check method component
     - type: python_script
@@ -32,8 +27,3 @@ functionality:
       path: /src/common/comp_tests/run_and_check_adata.py
     - path: /resources_test/batch_integration/pancreas
       dest: resources_test/batch_integration/pancreas
-    # # test config against schema
-    # - type: python_script
-    #   path: /src/common/check_yaml_schema/script.py
-    # - path: /src/common/api/schema_method.yaml
-    #   dest: schema.yaml

--- a/src/tasks/batch_integration/api/comp_method_feature.yaml
+++ b/src/tasks/batch_integration/api/comp_method_feature.yaml
@@ -17,11 +17,6 @@ functionality:
       __merge__: file_integrated_feature.yaml
       direction: output
       required: true
-    - name: --hvg
-      type: boolean
-      description: Whether to subset to highly variable genes
-      default: false
-      required: false
   test_resources:
     # check method component
     - type: python_script

--- a/src/tasks/batch_integration/api/comp_method_graph.yaml
+++ b/src/tasks/batch_integration/api/comp_method_graph.yaml
@@ -17,11 +17,6 @@ functionality:
       __merge__: file_integrated_graph.yaml
       direction: output
       required: true
-    - name: --hvg
-      type: boolean
-      description: Whether to subset to highly variable genes
-      default: false
-      required: false
   test_resources:
     # check method component
     - type: python_script

--- a/src/tasks/batch_integration/api/comp_process_dataset.yaml
+++ b/src/tasks/batch_integration/api/comp_process_dataset.yaml
@@ -16,6 +16,24 @@ functionality:
       __merge__: file_unintegrated.yaml
       direction: output
       required: true
+    - name: "--obs_label"
+      type: "string"
+      description: "Which .obs slot to use as label."
+      default: "celltype"
+    - name: "--obs_batch"
+      type: "string"
+      description: "Which .obs slot to use as batch covariate."
+      default: "batch"
+    - name: --hvgs
+      type: integer
+      description: Number of highly variable genes
+      default: 2000
+      required: false
+    - name: --subset_hvg
+      type: boolean
+      description: Whether to subset to highly variable genes
+      default: false
+      required: false
   test_resources:
     - path: /resources_test/common/pancreas/
       dest: resources_test/common/pancreas/

--- a/src/tasks/batch_integration/methods/bbknn/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/bbknn/config.vsh.yaml
@@ -19,12 +19,7 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       bbknn_full_unscaled:
-      bbknn_hvg_unscaled:
-        hvg: true
-      bbknn_hvg_scaled:
-        preferred_normalization: log_cpm_scaled
       bbknn_full_scaled:
-        hvg: true
         preferred_normalization: log_cpm_scaled
   resources:
     - type: python_script

--- a/src/tasks/batch_integration/methods/bbknn/script.py
+++ b/src/tasks/batch_integration/methods/bbknn/script.py
@@ -17,10 +17,6 @@ meta = {
 print('Read input', flush=True)
 input = ad.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    input = input[:, input.var['hvg']].copy()
-
 print('Run BBKNN', flush=True)
 input.X = input.layers['normalized']
 input = bbknn(input, batch='batch')

--- a/src/tasks/batch_integration/methods/combat/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/combat/config.vsh.yaml
@@ -22,12 +22,7 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       combat_full_unscaled:
-      combat_hvg_unscaled:
-        hvg: true
       combat_full_scaled:
-        preferred_normalization: log_cpm_scaled
-      combat_hvg_scaled:
-        hvg: true
         preferred_normalization: log_cpm_scaled
   resources:
     - type: python_script

--- a/src/tasks/batch_integration/methods/combat/script.py
+++ b/src/tasks/batch_integration/methods/combat/script.py
@@ -19,10 +19,6 @@ meta = {
 print('Read input', flush=True)
 adata = sc.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    adata = adata[:, adata.var['hvg']].copy()
-
 print('Run Combat', flush=True)
 adata.X = adata.layers['normalized']
 adata.X = sc.pp.combat(adata, key='batch', inplace=False)

--- a/src/tasks/batch_integration/methods/mnnpy/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/mnnpy/config.vsh.yaml
@@ -20,11 +20,6 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       mnn_full_unscaled:
-      mnn_hvg_unscaled:
-        hvg: true
-      mnn_hvg_scaled:
-        hvg: true
-        preferred_normalization: log_cpm_scaled
       mnn_full_scaled:
         preferred_normalization: log_cpm_scaled
   resources:

--- a/src/tasks/batch_integration/methods/mnnpy/script.py
+++ b/src/tasks/batch_integration/methods/mnnpy/script.py
@@ -16,10 +16,6 @@ meta = {
 print('Read input', flush=True)
 adata = ad.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    adata = adata[:, adata.var['hvg']]
-
 print('Run mnn', flush=True)
 adata.X = adata.layers['normalized']
 adata.layers['corrected_counts'] = mnn(adata, batch='batch').X

--- a/src/tasks/batch_integration/methods/scanorama_embed/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/scanorama_embed/config.vsh.yaml
@@ -17,11 +17,6 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       scanorama_embed_full_unscaled:
-      scanorama_embed_hvg_unscaled:
-        hvg: true
-      scanorama_embed_hvg_scaled:
-        hvg: true
-        preferred_normalization: log_cpm_scaled
       scanorama_embed_full_scaled:
         preferred_normalization: log_cpm_scaled
   resources:

--- a/src/tasks/batch_integration/methods/scanorama_embed/script.py
+++ b/src/tasks/batch_integration/methods/scanorama_embed/script.py
@@ -17,10 +17,6 @@ meta = {
 print('Read input', flush=True)
 adata = ad.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    adata = adata[:, adata.var['hvg']].copy()
-
 print('Run scanorama', flush=True)
 adata.X = adata.layers['normalized']
 adata.obsm['X_emb'] = scanorama(adata, batch='batch').obsm['X_emb']

--- a/src/tasks/batch_integration/methods/scanorama_feature/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/scanorama_feature/config.vsh.yaml
@@ -17,11 +17,6 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       scanorama_feature_full_unscaled:
-      scanorama_feature_hvg_unscaled:
-        hvg: true
-      scanorama_feature_hvg_scaled:
-        hvg: true
-        preferred_normalization: log_cpm_scaled
       scanorama_feature_full_scaled:
         preferred_normalization: log_cpm_scaled
   resources:

--- a/src/tasks/batch_integration/methods/scanorama_feature/script.py
+++ b/src/tasks/batch_integration/methods/scanorama_feature/script.py
@@ -17,10 +17,6 @@ meta = {
 print('Read input', flush=True)
 adata = ad.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    adata = adata[:, adata.var['hvg']]
-
 print('Run scanorama', flush=True)
 adata.X = adata.layers['normalized']
 adata.layers['corrected_counts'] = scanorama(adata, batch='batch').X

--- a/src/tasks/batch_integration/methods/scanvi/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/scanvi/config.vsh.yaml
@@ -28,8 +28,6 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       scanvi_full_unscaled:
-      scanvi_hvg_unscaled:
-        hvg: true
   resources:
     - type: python_script
       path: script.py

--- a/src/tasks/batch_integration/methods/scanvi/script.py
+++ b/src/tasks/batch_integration/methods/scanvi/script.py
@@ -19,9 +19,6 @@ meta = {
 print('Read input', flush=True)
 adata = ad.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    adata = adata[:, adata.var['hvg']].copy()
 
 print('Run scanvi', flush=True)
 adata.X = adata.layers['normalized']

--- a/src/tasks/batch_integration/methods/scvi/config.vsh.yaml
+++ b/src/tasks/batch_integration/methods/scvi/config.vsh.yaml
@@ -16,8 +16,6 @@ functionality:
     preferred_normalization: log_cpm
     variants:
       scvi_full_unscaled:
-      scvi_hvg_unscaled:
-        hvg: true
   resources:
     - type: python_script
       path: script.py

--- a/src/tasks/batch_integration/methods/scvi/script.py
+++ b/src/tasks/batch_integration/methods/scvi/script.py
@@ -17,10 +17,6 @@ meta = {
 print('Read input', flush=True)
 adata = ad.read_h5ad(par['input'])
 
-if par['hvg']:
-    print('Select HVGs', flush=True)
-    adata = adata[:, adata.var['hvg']].copy()
-
 print('Run scvi', flush=True)
 adata.X = adata.layers['normalized']
 adata = scvi(adata, batch='batch')

--- a/src/tasks/batch_integration/process_dataset/config.vsh.yaml
+++ b/src/tasks/batch_integration/process_dataset/config.vsh.yaml
@@ -2,20 +2,6 @@ __merge__: ../api/comp_process_dataset.yaml
 functionality:
   name: process_dataset
   description: Preprocess adata object for data integration
-  arguments:
-    - name: "--obs_label"
-      type: "string"
-      description: "Which .obs slot to use as label."
-      default: "celltype"
-    - name: "--obs_batch"
-      type: "string"
-      description: "Which .obs slot to use as batch covariate."
-      default: "batch"
-    - name: --hvgs
-      type: integer
-      description: Number of highly variable genes
-      default: 2000
-      required: false
   resources:
     - type: python_script
       path: script.py

--- a/src/tasks/batch_integration/process_dataset/script.py
+++ b/src/tasks/batch_integration/process_dataset/script.py
@@ -40,6 +40,10 @@ def compute_batched_hvg(adata, n_hvgs):
 print(f'Select {par["hvgs"]} highly variable genes', flush=True)
 adata_with_hvg = compute_batched_hvg(input, n_hvgs=par['hvgs'])
 
+if par['subset_hvg']:
+    print('Subsetting to HVG dimensions', flush=True)
+    adata_with_hvg = adata_with_hvg[:, adata_with_hvg.var['hvg']].copy()
+
 print(">> Figuring out which data needs to be copied to which output file", flush=True)
 # use par arguments to look for label and batch value in different slots
 slot_mapping = {


### PR DESCRIPTION
Having the --hvg argument in the methods inherently changes the dataset dimensions when a method is run, which is something which should be avoided, since it will change how the metrics work.

Actually, this is why most tasks have a [dataset]/[solution] split, so that methods can't (accidentally) alter the dataset object in order to achieve a better score.

@mumichae As part of this PR I'd like to:
  - Remove the --hvg argument from the methods and move it to the process dataset component, so that a dataset is subsampled if we only want to look at the hvg genes.
  - Make the process_dataset component generate a solution object, so a method can't cheat by making changes to the dataset h5ad file.

Is this ok with you?

## Describe your changes

* Remove --hvg argument from methods and move it to the process_dataset component

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [x] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!