### PR TITLE
FIx dataset simulator

### DIFF
--- a/src/tasks/spatial_decomposition/dataset_simulator/script.py
+++ b/src/tasks/spatial_decomposition/dataset_simulator/script.py
@@ -23,6 +23,7 @@ meta = {
 ## VIASH END
 
 CELLTYPE_MIN_CELLS = 25
+
 # Reading input dataset
 adata = ad.read_h5ad(par['input'])
 
@@ -189,8 +190,11 @@ adata_merged = generate_synthetic_dataset(adata,
 adata_merged.uns["spatial_data_summary"] = f"Dirichlet alpha={par['alpha']}"
 filter_genes_cells(adata_merged)
 adata_merged.X = None
-if "is_primary_data" in adata_merged.obs:
-    adata_merged.obs['is_primary_data'] = adata_merged.obs['is_primary_data'].fillna(False)
 
+for col in adata_merged.obs:
+    if adata_merged.obs[col].dtype == 'object':
+        adata_merged.obs[col] = adata_merged.obs[col].astype('category')
+
+print(adata_merged.obs)
 print("Writing output to file")
 adata_merged.write_h5ad(par["simulated_data"])

--- a/src/tasks/spatial_decomposition/dataset_simulator/script.py
+++ b/src/tasks/spatial_decomposition/dataset_simulator/script.py
@@ -27,6 +27,7 @@ CELLTYPE_MIN_CELLS = 25
 # Reading input dataset
 adata = ad.read_h5ad(par['input'])
 
+
 def generate_synthetic_dataset(
     adata: ad.AnnData,
     alpha: Union[float, Sequence] = 1.0,
@@ -163,11 +164,13 @@ def generate_synthetic_dataset(
     adata_merged.uns["cell_type_names"] = uni_labs
     return adata_merged
 
+
 def filter_celltypes(adata, min_cells=CELLTYPE_MIN_CELLS):
     """Filter rare celltypes from an AnnData"""
     celltype_counts = adata.obs["cell_type"].value_counts() >= min_cells
     keep_cells = np.isin(adata.obs["cell_type"], celltype_counts.index[celltype_counts])
     return adata[adata.obs.index[keep_cells]].copy()
+
 
 def filter_genes_cells(adata):
     """Remove empty cells and genes."""
@@ -176,6 +179,7 @@ def filter_genes_cells(adata):
         adata.uns["var_names_all"] = adata.var.index.to_numpy()
     sc.pp.filter_genes(adata, min_cells=1)
     sc.pp.filter_cells(adata, min_counts=2)
+
 
 adata.X = adata.layers["counts"]
 sc.pp.filter_genes(adata, min_counts=10)
@@ -191,10 +195,14 @@ adata_merged.uns["spatial_data_summary"] = f"Dirichlet alpha={par['alpha']}"
 filter_genes_cells(adata_merged)
 adata_merged.X = None
 
+# Convert non-string objects to categoricals to avoid
+# TypeError: Can't implicitly convert non-string objects to strings
+# In this case, the error is raised when there are NA values in .obs columns with dtype object (boolean).
+# The resulting anndata object cannot be written to a file.
+# This conversion is handled in later versions of anndata (0.10)
 for col in adata_merged.obs:
     if adata_merged.obs[col].dtype == 'object':
         adata_merged.obs[col] = adata_merged.obs[col].astype('category')
 
-print(adata_merged.obs)
 print("Writing output to file")
 adata_merged.write_h5ad(par["simulated_data"])


### PR DESCRIPTION
## Describe your changes
While merging the simulated spatial data with the original anndata object, NA values are introduced in .obs slots. In this case, due to NA values in columns with booleans, a TypeError is raised while writing the anndata objects to files. The current version of anndata being used does not implicitly convert non-string objects to strings while writing to files, thereby raising a TypeError. This PR is a temporary solution to fix this issue. The conversion is implicitly handled in later versions of anndata (0.10).

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [x] CI Tests succeed and look good!

## Requirements after merging

- [ ] Need to regenerate `common/` resources

- [ ] Need to regenerate task-specific resources. Specify: <all or ...>